### PR TITLE
feat: [SEISMO-0016, 0017] Improve response messages to slink2dali

### DIFF
--- a/src/authserver_response_codes.h
+++ b/src/authserver_response_codes.h
@@ -1,5 +1,5 @@
-#ifndef RESPONSE_CODES_H
-#define RESPONSE_CODES_H
+#ifndef AUTHSERVER_RESPONSE_CODES_H
+#define AUTHSERVER_RESPONSE_CODES_H
 
 // Define constant integer values for response status codes
 #define GENERIC_SUCCESS                 0
@@ -58,4 +58,4 @@
 #define VERIFICATION_INVALID_ROLE_MSG       "Verification error: Invalid role in token"
 #define VERIFICATION_EXPIRED_TOKEN_MSG      "Verification error: Expired token"
 
-#endif  /* RESPONSE_CODES_H */
+#endif  /* AUTHSERVER_RESPONSE_CODES_H */

--- a/src/dlclient.c
+++ b/src/dlclient.c
@@ -205,8 +205,8 @@ DLHandleCmd (ClientInfo *cinfo)
 
       lprintf (1, "[%s] %s: Data packet received from client without write permission",
           cinfo->hostname, WRITE_UNAUTHORIZED_ERROR_STR);
-      snprintf (replystr, sizeof (replystr), "%s: Write request not granted, no token provided",
-          WRITE_UNAUTHORIZED_ERROR_STR);
+      snprintf (replystr, sizeof (replystr), "%s(%d): Write request not granted, no token provided",
+          WRITE_UNAUTHORIZED_ERROR_STR, WRITE_UNAUTHORIZED_ERROR);
       SendPacket (cinfo, "ERROR",replystr, 0, 1, 1);
 
       return -1;
@@ -715,8 +715,8 @@ HandleNegotiation (ClientInfo *cinfo)
     if (size > DLMAXREGEXLEN)
     {
       lprintf (0, "[%s] %s: Authorization token too large (%d)", cinfo->hostname, AUTH_TOKEN_SIZE_ERROR_STR, size);
-      snprintf (sendbuffer, sizeof (sendbuffer), "%s: Authorization token too large (%d), must be <= %d",
-                AUTH_TOKEN_SIZE_ERROR_STR, size, DLMAXREGEXLEN);
+      snprintf (sendbuffer, sizeof (sendbuffer), "%s(%d): Authorization token too large (%d), must be <= %d",
+                AUTH_TOKEN_SIZE_ERROR_STR, AUTH_TOKEN_SIZE_ERROR, size, DLMAXREGEXLEN);
       if (SendPacket (cinfo, "ERROR", sendbuffer, 0, 1, 1)) {
         return -1;
       } else {
@@ -730,7 +730,8 @@ HandleNegotiation (ClientInfo *cinfo)
       lprintf (0, "[%s] %s: Cannot authorize for write, AuthServer-setting not configured", cinfo->hostname, AUTH_INTERNAL_ERROR_STR);
 
       snprintf (sendbuffer, sizeof (sendbuffer),
-          "%s: Cannot authorize for write, RingServer not properly configured", AUTH_INTERNAL_ERROR_STR);
+          "%s(%d): Cannot authorize for write, RingServer not properly configured",
+          AUTH_INTERNAL_ERROR_STR, AUTH_INTERNAL_ERROR);
       if (SendPacket (cinfo, "ERROR", sendbuffer, 0, 1, 1)) {
         return -1;
       } else {
@@ -744,7 +745,8 @@ HandleNegotiation (ClientInfo *cinfo)
       lprintf (0, "[%s] %s: Cannot authorize for write, BearerToken-setting not configured", cinfo->hostname, AUTH_INTERNAL_ERROR_STR);
 
       snprintf (sendbuffer, sizeof (sendbuffer),
-          "%s: Cannot authorize for write, RingServer not properly configured", AUTH_INTERNAL_ERROR_STR);
+          "%s(%d): Cannot authorize for write, RingServer not properly configured",
+          AUTH_INTERNAL_ERROR_STR, AUTH_INTERNAL_ERROR);
       if (SendPacket (cinfo, "ERROR", sendbuffer, 0, 1, 1)) {
         return -1;
       } else {
@@ -947,7 +949,8 @@ HandleNegotiation (ClientInfo *cinfo)
           if (errptr){
             lprintf (0, "[%s] %s: Error with JWTToken & pcre_compile: %s (offset: %d)", cinfo->hostname,
                 AUTH_INTERNAL_ERROR_STR, errptr, erroffset);
-            snprintf (sendbuffer, sizeof (sendbuffer), "%s: Internal error occured on RingServer", AUTH_INTERNAL_ERROR_STR);
+            snprintf (sendbuffer, sizeof (sendbuffer), "%s(%d): Internal error occured on RingServer",
+                AUTH_INTERNAL_ERROR_STR, AUTH_INTERNAL_ERROR);
 
             if (SendPacket (cinfo, "ERROR", sendbuffer, 0, 1, 1))
               ret = -1;
@@ -996,7 +999,9 @@ HandleNegotiation (ClientInfo *cinfo)
       cinfo->authorized = 1;
 
       lprintf (1, "[%s] %s: Granted authorization to WRITE on streamIds", cinfo->hostname, AUTH_SUCCESS_STR);
-      snprintf (sendbuffer, sizeof (sendbuffer), "%s: Granted authorization to WRITE on streamIds", AUTH_SUCCESS_STR);
+      snprintf (sendbuffer, sizeof (sendbuffer),
+          "%s(%d): Granted authorization to WRITE on streamIds",
+          AUTH_SUCCESS_STR, AUTH_SUCCESS);
 
       if (SendPacket (cinfo, "OK", sendbuffer, 0, 1, 1))
         ret = -1;
@@ -1022,21 +1027,24 @@ HandleNegotiation (ClientInfo *cinfo)
     else if (authserver_response_code == INBEHALF_VERIFICATION_INVALID_TOKEN)
     {
       lprintf (0, "[%s] %s: Sensor token invalid", cinfo->hostname, AUTH_INVALID_TOKEN_ERROR_STR);
-      snprintf (sendbuffer, sizeof (sendbuffer), "%s: Sensor token invalid", AUTH_INVALID_TOKEN_ERROR_STR);
+      snprintf (sendbuffer, sizeof (sendbuffer), "%s(%d): Sensor token invalid",
+          AUTH_INVALID_TOKEN_ERROR_STR, AUTH_INVALID_TOKEN_ERROR);
       if (SendPacket (cinfo, "ERROR", sendbuffer, 0, 1, 1))
         ret = -1;
     }
     else if (authserver_response_code == INBEHALF_VERIFICATION_INVALID_ROLE)
     {
       lprintf (0, "[%s] %s: Role in token invalid", cinfo->hostname, AUTH_ROLE_INVALID_ERROR_STR);
-      snprintf (sendbuffer, sizeof (sendbuffer), "%s: Role in token invalid", AUTH_ROLE_INVALID_ERROR_STR);
+      snprintf (sendbuffer, sizeof (sendbuffer), "%s(%d): Role in token invalid",
+          AUTH_ROLE_INVALID_ERROR_STR, AUTH_ROLE_INVALID_ERROR);
       if (SendPacket (cinfo, "ERROR", sendbuffer, 0, 1, 1))
         ret = -1;
     }
     else if (authserver_response_code == INBEHALF_VERIFICATION_EXPIRED_TOKEN)
     {
       lprintf (0, "[%s] %s: Expired sensor token", cinfo->hostname, AUTH_EXPIRED_TOKEN_ERROR_STR);
-      snprintf (sendbuffer, sizeof (sendbuffer), "%s: Expired sensor token", AUTH_EXPIRED_TOKEN_ERROR_STR);
+      snprintf (sendbuffer, sizeof (sendbuffer), "%s(%d): Expired sensor token",
+          AUTH_EXPIRED_TOKEN_ERROR_STR, AUTH_EXPIRED_TOKEN_ERROR);
       if (SendPacket (cinfo, "ERROR", sendbuffer, 0, 1, 1))
         ret = -1;
     }
@@ -1045,8 +1053,8 @@ HandleNegotiation (ClientInfo *cinfo)
       // TODO: Specifically handle other cases such as the VERIFICATION cases for bearertoken
       lprintf (0, "[%s] %s: Error code from AuthServer = %d", cinfo->hostname, AUTH_INTERNAL_ERROR_STR,
           authserver_response_code);
-      snprintf (sendbuffer, sizeof (sendbuffer), "%s: Internal error occured on RingServer",
-          AUTH_INTERNAL_ERROR_STR);
+      snprintf (sendbuffer, sizeof (sendbuffer), "%s(%d): Internal error occured on RingServer",
+          AUTH_INTERNAL_ERROR_STR, AUTH_INTERNAL_ERROR);
       if (SendPacket (cinfo, "ERROR", sendbuffer, 0, 1, 1))
         ret = -1;
     }
@@ -1121,8 +1129,8 @@ HandleWrite (ClientInfo *cinfo)
   {
     lprintf (1, "[%s] %s: Error parsing WRITE parameters: %.100s",
              cinfo->hostname, WRITE_FORMAT_ERROR_STR, cinfo->recvbuf);
-    snprintf (replystr, sizeof (replystr), "%s: Error parsing your WRITE command parameters",
-        WRITE_FORMAT_ERROR_STR);
+    snprintf (replystr, sizeof (replystr), "%s(%d): Error parsing your WRITE command parameters",
+        WRITE_FORMAT_ERROR_STR, WRITE_FORMAT_ERROR);
     SendPacket (cinfo, "ERROR", replystr, 0, 1, 1);
 
     return -1;
@@ -1133,8 +1141,8 @@ HandleWrite (ClientInfo *cinfo)
   {
     lprintf (1, "[%s] %s: Client has no linked devices, %s is not linked",
              cinfo->hostname, WRITE_NO_DEVICE_ERROR_STR, streamid);
-    snprintf (replystr, sizeof (replystr), "%s: You have no linked devices, %s is not linked",
-        WRITE_NO_DEVICE_ERROR_STR, streamid);
+    snprintf (replystr, sizeof (replystr), "%s(%d): You have no linked devices, %s is not linked",
+        WRITE_NO_DEVICE_ERROR_STR, WRITE_NO_DEVICE_ERROR, streamid);
     SendPacket (cinfo, "ERROR", replystr, 0, 1, 1);
 
     return -1;
@@ -1145,7 +1153,8 @@ HandleWrite (ClientInfo *cinfo)
   if (currTime > cinfo->tokenExpiry) {
     lprintf (1, "[%s] %s: Client token expired: %lu > %d",
              cinfo->hostname, WRITE_EXPIRED_TOKEN_ERROR_STR, currTime, cinfo->tokenExpiry);
-    snprintf (replystr, sizeof (replystr), "%s: Your token has expired", WRITE_EXPIRED_TOKEN_ERROR_STR);
+    snprintf (replystr, sizeof (replystr), "%s(%d): Your token has expired",
+        WRITE_EXPIRED_TOKEN_ERROR_STR, WRITE_EXPIRED_TOKEN_ERROR);
     SendPacket (cinfo, "ERROR", replystr, 0, 1, 1);
     return -1;
   }
@@ -1176,8 +1185,8 @@ HandleWrite (ClientInfo *cinfo)
   {
       lprintf (1, "[%s] %s: Client not authorized to WRITE on streamid: %s, pcre_result: %d",
                cinfo->hostname, WRITE_STREAM_UNAUTHORIZED_ERROR_STR, streamid, pcre_result);
-      snprintf (replystr, sizeof (replystr), "%s: You are not authorized to WRITE on %s",
-          WRITE_STREAM_UNAUTHORIZED_ERROR_STR, streamid);
+      snprintf (replystr, sizeof (replystr), "%s(%d): You are not authorized to WRITE on %s",
+          WRITE_STREAM_UNAUTHORIZED_ERROR_STR, WRITE_STREAM_UNAUTHORIZED_ERROR, streamid);
       SendPacket (cinfo, "ERROR", replystr, 0, 1, 1);
 
       return -1;

--- a/src/dlclient.c
+++ b/src/dlclient.c
@@ -706,7 +706,7 @@ HandleNegotiation (ClientInfo *cinfo)
     {
       lprintf (0, "[%s] %s: AUTHORIZATION requires a single argument", cinfo->hostname, AUTH_FORMAT_ERROR_STR);
       snprintf (sendbuffer, sizeof (sendbuffer), "%s(%d): AUTHORIZATION requires a single argument",
-                AUTH_FORMAT_ERROR, AUTH_FORMAT_ERROR_STR);
+                AUTH_FORMAT_ERROR_STR, AUTH_FORMAT_ERROR);
       if (SendPacket (cinfo, "ERROR", sendbuffer, 0, 1, 1)){
         return -1;
       } else {
@@ -1248,7 +1248,7 @@ HandleWrite (ClientInfo *cinfo)
           {
             lprintf (1, "[%s] Error writing miniSEED to disk", cinfo->hostname);
             snprintf (replystr, sizeof (replystr), "%s(%d): Error writing miniSEED to disk",
-                      WRITE_INTERNAL_ERROR_STR, WRITE_INTERNAL_ERROR,
+                      WRITE_INTERNAL_ERROR_STR, WRITE_INTERNAL_ERROR);
             SendPacket (cinfo, "ERROR", replystr, 0, 1, 1);
 
             return -1;
@@ -1270,7 +1270,7 @@ HandleWrite (ClientInfo *cinfo)
       lprintf (1, "[%s] %s: Error with RingWrite", cinfo->hostname, WRITE_INTERNAL_ERROR_STR);
 
     snprintf (replystr, sizeof (replystr), "%s(%d): Error adding packet to ring",
-              WRITE_INTERNAL_ERROR_STR, WRITE_INTERNAL_ERROR,
+              WRITE_INTERNAL_ERROR_STR, WRITE_INTERNAL_ERROR);
     SendPacket (cinfo, "ERROR", replystr, 0, 1, 1);
 
     /* Set the shutdown signal if ring corruption was detected */
@@ -1309,7 +1309,7 @@ HandleWrite (ClientInfo *cinfo)
   if (strchr (flags, 'A'))
   {
     snprintf (replystr, sizeof (replystr), "%s(%d): Packet written in RingServer",
-              WRITE_SUCCESS_STR, WRITE_SUCCESS,
+              WRITE_SUCCESS_STR, WRITE_SUCCESS);
     if (SendPacket (cinfo, "OK", replystr, cinfo->packet.pktid, 1, 1))
       return -1;
   }

--- a/src/dlclient.c
+++ b/src/dlclient.c
@@ -1183,13 +1183,13 @@ HandleWrite (ClientInfo *cinfo)
   }
   else
   {
-      lprintf (1, "[%s] %s: Client not authorized to WRITE on streamid: %s, pcre_result: %d",
+      lprintf (1, "[%s] %s: Dropping packet. Client not authorized to WRITE on streamid: %s, pcre_result: %d",
                cinfo->hostname, WRITE_STREAM_UNAUTHORIZED_ERROR_STR, streamid, pcre_result);
-      snprintf (replystr, sizeof (replystr), "%s(%d): You are not authorized to WRITE on %s",
+      snprintf (replystr, sizeof (replystr), "%s(%d): Dropping packet. You are not authorized to WRITE on %s",
           WRITE_STREAM_UNAUTHORIZED_ERROR_STR, WRITE_STREAM_UNAUTHORIZED_ERROR, streamid);
       SendPacket (cinfo, "ERROR", replystr, 0, 1, 1);
 
-      return -1;
+      return 0; // Ignore packet, don't disconnect
   }
 
   /* Copy the stream ID */

--- a/src/dlclient.c
+++ b/src/dlclient.c
@@ -1244,8 +1244,9 @@ HandleWrite (ClientInfo *cinfo)
           if (ds_streamproc (cinfo->mswrite, msr, fn, cinfo->hostname))
           {
             lprintf (1, "[%s] Error writing miniSEED to disk", cinfo->hostname);
-
-            SendPacket (cinfo, "ERROR", "Error writing miniSEED to disk", 0, 1, 1);
+            snprintf (replystr, sizeof (replystr), "%s(%d): Error writing miniSEED to disk",
+                      WRITE_INTERNAL_ERROR_STR, WRITE_INTERNAL_ERROR,
+            SendPacket (cinfo, "ERROR", replystr, 0, 1, 1);
 
             return -1;
           }

--- a/src/dlclient.c
+++ b/src/dlclient.c
@@ -704,7 +704,10 @@ HandleNegotiation (ClientInfo *cinfo)
     /* Make sure we got a single pattern or no pattern */
     if (fields > 1)
     {
-      if (SendPacket (cinfo, "ERROR", "AUTHORIZATION requires a single argument", 0, 1, 1)){
+      lprintf (0, "[%s] %s: AUTHORIZATION requires a single argument", cinfo->hostname, AUTH_FORMAT_ERROR_STR);
+      snprintf (sendbuffer, sizeof (sendbuffer), "%s(%d): AUTHORIZATION requires a single argument",
+                AUTH_FORMAT_ERROR, AUTH_FORMAT_ERROR_STR);
+      if (SendPacket (cinfo, "ERROR", sendbuffer, 0, 1, 1)){
         return -1;
       } else {
         return 0; // means negotiation completed (we've responded)

--- a/src/dlclient.c
+++ b/src/dlclient.c
@@ -1201,10 +1201,12 @@ HandleWrite (ClientInfo *cinfo)
   /* Make sure this packet data would fit into the ring */
   if (cinfo->packet.datasize > cinfo->ringparams->pktsize)
   {
-    lprintf (1, "[%s] Submitted packet size (%d) is greater than ring packet size (%d)",
-             cinfo->hostname, cinfo->packet.datasize, cinfo->ringparams->pktsize);
+    lprintf (1, "[%s] %s: Submitted packet size (%d) is greater than ring packet size (%d)",
+             cinfo->hostname, WRITE_LARGE_PACKET_ERROR_STR,
+             cinfo->packet.datasize, cinfo->ringparams->pktsize);
 
-    snprintf (replystr, sizeof (replystr), "Packet size (%d) is too large for ring, maximum is %d bytes",
+    snprintf (replystr, sizeof (replystr), "%s(%d): Packet size (%d) is too large for ring, maximum is %d bytes",
+              WRITE_LARGE_PACKET_ERROR_STR, WRITE_LARGE_PACKET_ERROR,
               cinfo->packet.datasize, cinfo->ringparams->pktsize);
     SendPacket (cinfo, "ERROR", replystr, 0, 1, 1);
 
@@ -1261,9 +1263,11 @@ HandleWrite (ClientInfo *cinfo)
     if (rv == -2)
       lprintf (1, "[%s] Error with RingWrite, corrupt ring, shutdown signalled", cinfo->hostname);
     else
-      lprintf (1, "[%s] Error with RingWrite", cinfo->hostname);
+      lprintf (1, "[%s] %s: Error with RingWrite", cinfo->hostname, WRITE_INTERNAL_ERROR_STR);
 
-    SendPacket (cinfo, "ERROR", "Error adding packet to ring", 0, 1, 1);
+    snprintf (replystr, sizeof (replystr), "%s(%d): Error adding packet to ring",
+              WRITE_INTERNAL_ERROR_STR, WRITE_INTERNAL_ERROR,
+    SendPacket (cinfo, "ERROR", replystr, 0, 1, 1);
 
     /* Set the shutdown signal if ring corruption was detected */
     if (rv == -2)
@@ -1300,7 +1304,9 @@ HandleWrite (ClientInfo *cinfo)
   /* Send acknowledgement if requested (flags contain 'A') */
   if (strchr (flags, 'A'))
   {
-    if (SendPacket (cinfo, "OK", "WRITE_OK: Packet written in server", cinfo->packet.pktid, 1, 1))
+    snprintf (replystr, sizeof (replystr), "%s(%d): Packet written in RingServer",
+              WRITE_SUCCESS_STR, WRITE_SUCCESS,
+    if (SendPacket (cinfo, "OK", replystr, cinfo->packet.pktid, 1, 1))
       return -1;
   }
 

--- a/src/ringserver_response_codes.h
+++ b/src/ringserver_response_codes.h
@@ -11,18 +11,21 @@
  * 2 = AUTHENTICATION group
  * 1 = 1st type of response within authentication group  (note: types start at 0 / 0th)
  * 0 = Success code
+ *
+ * Note: Always use the most specific and apt status code for your scenario
  */
 
 // Define constant integer values for response status codes
 #define GENERIC_SUCCESS                 0
 #define GENERIC_ERROR                   1
 
-#define WRITE_SUCCESS                   100
-#define WRITE_ERROR                     101
-#define WRITE_UNAUTHORIZED              111  // Client has no write permission (token)
-#define WRITE_STREAM_UNAUTHORIZED       121  // Client has write permission (token) but doesn't authorize write on this stream
-#define WRITE_NO_DEVICE_LINKED          131  // Client has write permission (token) but has no specified device to write on
-#define WRITE_EXPIRED_TOKEN             141  // Client's write permission (token) is expired
+#define WRITE_SUCCESS                   100  // Catch all success
+#define WRITE_ERROR                     101  // Catch all error
+#define WRITE_INTERNAL ERROR            111  // Error due to error in ringserver
+#define WRITE_UNAUTHORIZED              121  // Client has no write permission (token)
+#define WRITE_STREAM_UNAUTHORIZED       131  // Client has write permission (token) but doesn't authorize write on this stream
+#define WRITE_NO_DEVICE_LINKED          141  // Client has write permission (token) but has no specified device to write on
+#define WRITE_EXPIRED_TOKEN             151  // Client's write permission (token) is expired
                                       
 // Define response codes as strings
 #define GENERIC_SUCCESS_STR                 "GENERIC_SUCCESS"

--- a/src/ringserver_response_codes.h
+++ b/src/ringserver_response_codes.h
@@ -1,11 +1,11 @@
 #ifndef RINGSERVER_RESPONSE_CODES_H
 #define RINGSERVER_RESPONSE_CODES_H
 
-/* Status Code Format: XYZ 
+/* Status Code Format: XYZ
  * X : 0-n based on response group (ie GENERIC is 0, WRITE is 1, AUTH(ORIZATION) is 2, and so on)
  * Y : 0-n increments as type changes within a response group
  * Z : 0 if success type, 1 if error type
- * 
+ *
  * For example:
  * 210 :
  * 2 = AUTHENTICATION group
@@ -26,7 +26,7 @@
 #define WRITE_STREAM_UNAUTHORIZED_ERROR   131  // Client has write permission (token) but doesn't authorize write on this stream
 #define WRITE_NO_DEVICE_ERROR             141  // Client has write permission (token) but has no specified device to write on
 #define WRITE_EXPIRED_TOKEN_ERROR         151  // Client's write permission (token) is expired
-#define WRITE_FORMAT_ERROR                161  // Error in write command formatting leading to parsing error                                              
+#define WRITE_FORMAT_ERROR                161  // Error in write command formatting leading to parsing error
 #define WRITE_LARGE_PACKET_ERROR          171  // Packet is larger than ring packet size
 
 #define AUTH_SUCCESS                      200  // Catch all success

--- a/src/ringserver_response_codes.h
+++ b/src/ringserver_response_codes.h
@@ -26,6 +26,7 @@
 #define WRITE_STREAM_UNAUTHORIZED_ERROR   131  // Client has write permission (token) but doesn't authorize write on this stream
 #define WRITE_NO_DEVICE_ERROR             141  // Client has write permission (token) but has no specified device to write on
 #define WRITE_EXPIRED_TOKEN_ERROR         151  // Client's write permission (token) is expired
+#define WRITE_FORMAT_ERROR                161  // Error in write command formatting leading to parsing error                                              
                                              
 #define AUTH_SUCCESS                      200  // Catch all success
 #define AUTH_ERROR                        201  // Catch all error
@@ -47,6 +48,7 @@
 #define WRITE_STREAM_UNAUTHORIZED_ERROR_STR  "WRITE_STREAM_UNAUTHORIZED_ERROR"
 #define WRITE_NO_DEVICE_ERROR_STR            "WRITE_NO_DEVICE_ERROR"
 #define WRITE_EXPIRED_TOKEN_ERROR_STR        "WRITE_EXPIRED_TOKEN_ERROR"
+#define WRITE_FORMAT_ERROR_STR               "WRITE_FORMAT_ERROR"
 
 #define AUTH_SUCCESS_STR                     "AUTH_SUCCESS"
 #define AUTH_ERROR_STR                       "AUTH_ERROR"

--- a/src/ringserver_response_codes.h
+++ b/src/ringserver_response_codes.h
@@ -27,8 +27,8 @@
 #define WRITE_NO_DEVICE_ERROR             141  // Client has write permission (token) but has no specified device to write on
 #define WRITE_EXPIRED_TOKEN_ERROR         151  // Client's write permission (token) is expired
                                              
-#define AUTH_SUCCESS                      200
-#define AUTH_ERROR                        201
+#define AUTH_SUCCESS                      200  // Catch all success
+#define AUTH_ERROR                        201  // Catch all error
 #define AUTH_INTERNAL_ERROR               211  // Error due to error within ringserver processes
 #define AUTH_TOKEN_SIZE_ERROR             221  // Size of token isn't as expected (ie too large)
 #define AUTH_INVALID_TOKEN_ERROR          231  // Token is not a valid token from AuthServer
@@ -37,18 +37,23 @@
                                                                                              
                                       
 // Define response codes as strings
-#define GENERIC_SUCCESS_STR                 "GENERIC_SUCCESS"
-#define GENERIC_ERROR_STR                   "GENERIC_ERROR"
+#define GENERIC_SUCCESS_STR                  "GENERIC_SUCCESS"
+#define GENERIC_ERROR_STR                    "GENERIC_ERROR"
 
-#define WRITE_SUCCESS_STR                   "WRITE_SUCCESS"
-#define WRITE_ERROR_STR                     "WRITE_ERROR"
+#define WRITE_SUCCESS_STR                    "WRITE_SUCCESS"
+#define WRITE_ERROR_STR                      "WRITE_ERROR"
+#define WRITE_INTERNAL_ERROR_STR             "WRITE_INTERNAL_ERROR"
+#define WRITE_UNAUTHORIZED_ERROR_STR         "WRITE_UNAUTHORIZED_ERROR"
+#define WRITE_STREAM_UNAUTHORIZED_ERROR_STR  "WRITE_STREAM_UNAUTHORIZED_ERROR"
+#define WRITE_NO_DEVICE_ERROR_STR            "WRITE_NO_DEVICE_ERROR"
+#define WRITE_EXPIRED_TOKEN_ERROR_STR        "WRITE_EXPIRED_TOKEN_ERROR"
 
-#define AUTH_SUCCESS_STR           "AUTH_SUCCESS"
-#define AUTH_ERROR_STR             "AUTH_ERROR"
-
-// Define the default messages for each response status code
-#define GENERIC_SUCCESS_MSG                 "Success"
-#define GENERIC_ERROR_MSG                   "Error"
-
+#define AUTH_SUCCESS_STR                     "AUTH_SUCCESS"
+#define AUTH_ERROR_STR                       "AUTH_ERROR"
+#define AUTH_INTERNAL_ERROR_STR              "AUTH_INTERNAL_ERROR"
+#define AUTH_TOKEN_SIZE_ERROR_STR            "AUTH_TOKEN_SIZE_ERROR"
+#define AUTH_INVALID_TOKEN_ERROR_STR         "AUTH_INVALID_TOKEN_ERROR"
+#define AUTH_ROLE_INVALID_ERROR_STR          "AUTH_ROLE_INVALID_ERROR"
+#define AUTH_EXPIRED_TOKEN_ERROR_STR         "AUTH_EXPIRED_TOKEN_ERROR"
 
 #endif  /* RINGSERVER_RESPONSE_CODES_H */

--- a/src/ringserver_response_codes.h
+++ b/src/ringserver_response_codes.h
@@ -1,0 +1,17 @@
+#ifndef RINGSERVER_RESPONSE_CODES_H
+#define RINGSERVER_RESPONSE_CODES_H
+
+// Define constant integer values for response status codes
+#define GENERIC_SUCCESS                 0
+#define GENERIC_ERROR                   1
+
+// Define response codes as strings
+#define GENERIC_SUCCESS_STR                 "GENERIC_SUCCESS"
+#define GENERIC_ERROR_STR                   "GENERIC_ERROR"
+
+// Define the default messages for each response status code
+#define GENERIC_SUCCESS_MSG                 "Success"
+#define GENERIC_ERROR_MSG                   "Error"
+
+
+#endif  /* RINGSERVER_RESPONSE_CODES_H */

--- a/src/ringserver_response_codes.h
+++ b/src/ringserver_response_codes.h
@@ -21,13 +21,14 @@
 
 #define WRITE_SUCCESS                     100  // Catch all success
 #define WRITE_ERROR                       101  // Catch all error
-#define WRITE_INTERNAL_ERROR              111  // Error due to error in ringserver
+#define WRITE_INTERNAL_ERROR              111  // Error due to error in ringserver, when there's nothing slink2dali can do about
 #define WRITE_UNAUTHORIZED_ERROR          121  // Client has no write permission (token)
 #define WRITE_STREAM_UNAUTHORIZED_ERROR   131  // Client has write permission (token) but doesn't authorize write on this stream
 #define WRITE_NO_DEVICE_ERROR             141  // Client has write permission (token) but has no specified device to write on
 #define WRITE_EXPIRED_TOKEN_ERROR         151  // Client's write permission (token) is expired
 #define WRITE_FORMAT_ERROR                161  // Error in write command formatting leading to parsing error                                              
-                                             
+#define WRITE_LARGE_PACKET_ERROR          171  // Packet is larger than ring packet size
+
 #define AUTH_SUCCESS                      200  // Catch all success
 #define AUTH_ERROR                        201  // Catch all error
 #define AUTH_INTERNAL_ERROR               211  // Error due to error within ringserver processes
@@ -35,8 +36,8 @@
 #define AUTH_INVALID_TOKEN_ERROR          231  // Token is not a valid token from AuthServer
 #define AUTH_ROLE_INVALID_ERROR           241  // Role in token isn't what's expected (ie should be sensor)
 #define AUTH_EXPIRED_TOKEN_ERROR          251  // Token is expired
-                                                                                             
-                                      
+
+
 // Define response codes as strings
 #define GENERIC_SUCCESS_STR                  "GENERIC_SUCCESS"
 #define GENERIC_ERROR_STR                    "GENERIC_ERROR"
@@ -49,6 +50,7 @@
 #define WRITE_NO_DEVICE_ERROR_STR            "WRITE_NO_DEVICE_ERROR"
 #define WRITE_EXPIRED_TOKEN_ERROR_STR        "WRITE_EXPIRED_TOKEN_ERROR"
 #define WRITE_FORMAT_ERROR_STR               "WRITE_FORMAT_ERROR"
+#define WRITE_LARGE_PACKET_ERROR_STR         "WRITE_LARGE_PACKET_ERROR"
 
 #define AUTH_SUCCESS_STR                     "AUTH_SUCCESS"
 #define AUTH_ERROR_STR                       "AUTH_ERROR"

--- a/src/ringserver_response_codes.h
+++ b/src/ringserver_response_codes.h
@@ -1,13 +1,38 @@
 #ifndef RINGSERVER_RESPONSE_CODES_H
 #define RINGSERVER_RESPONSE_CODES_H
 
+/* Status Code Format: XYZ 
+ * X : 0-n based on response group (ie GENERIC is 0, WRITE is 1, AUTHORIZATION is 2, and so on)
+ * Y : 0-n increments as type changes within a response group
+ * Z : 0 if success type, 1 if error type
+ * 
+ * For example:
+ * 210 :
+ * 2 = AUTHENTICATION group
+ * 1 = 1st type of response within authentication group  (note: types start at 0 / 0th)
+ * 0 = Success code
+ */
+
 // Define constant integer values for response status codes
 #define GENERIC_SUCCESS                 0
 #define GENERIC_ERROR                   1
 
+#define WRITE_SUCCESS                   100
+#define WRITE_ERROR                     101
+#define WRITE_UNAUTHORIZED              111  // Client has no write permission (token)
+#define WRITE_STREAM_UNAUTHORIZED       121  // Client has write permission (token) but doesn't authorize write on this stream
+#define WRITE_NO_DEVICE_LINKED          131  // Client has write permission (token) but has no specified device to write on
+#define WRITE_EXPIRED_TOKEN             141  // Client's write permission (token) is expired
+                                      
 // Define response codes as strings
 #define GENERIC_SUCCESS_STR                 "GENERIC_SUCCESS"
 #define GENERIC_ERROR_STR                   "GENERIC_ERROR"
+
+#define WRITE_SUCCESS_STR                   "WRITE_SUCCESS"
+#define WRITE_ERROR_STR                     "WRITE_ERROR"
+
+#define AUTHORIZATION_SUCCESS_STR           "AUTHORIZATION_SUCCESS"
+#define AUTHORIZATION_ERROR_STR             "AUTHORIZATION_ERROR"
 
 // Define the default messages for each response status code
 #define GENERIC_SUCCESS_MSG                 "Success"

--- a/src/ringserver_response_codes.h
+++ b/src/ringserver_response_codes.h
@@ -36,6 +36,7 @@
 #define AUTH_INVALID_TOKEN_ERROR          231  // Token is not a valid token from AuthServer
 #define AUTH_ROLE_INVALID_ERROR           241  // Role in token isn't what's expected (ie should be sensor)
 #define AUTH_EXPIRED_TOKEN_ERROR          251  // Token is expired
+#define AUTH_FORMAT_ERROR                 261  // Error in auth command formatting (ie no args given)
 
 
 // Define response codes as strings
@@ -59,5 +60,6 @@
 #define AUTH_INVALID_TOKEN_ERROR_STR         "AUTH_INVALID_TOKEN_ERROR"
 #define AUTH_ROLE_INVALID_ERROR_STR          "AUTH_ROLE_INVALID_ERROR"
 #define AUTH_EXPIRED_TOKEN_ERROR_STR         "AUTH_EXPIRED_TOKEN_ERROR"
+#define AUTH_FORMAT_ERROR_STR                "AUTH_FORMAT_ERROR"
 
 #endif  /* RINGSERVER_RESPONSE_CODES_H */

--- a/src/ringserver_response_codes.h
+++ b/src/ringserver_response_codes.h
@@ -16,8 +16,8 @@
  */
 
 // Define constant integer values for response status codes
-#define GENERIC_SUCCESS                   0
-#define GENERIC_ERROR                     1
+#define GENERIC_RINGSERVER_SUCCESS        0
+#define GENERIC_RINGSERVER_ERROR          1
 
 #define WRITE_SUCCESS                     100  // Catch all success
 #define WRITE_ERROR                       101  // Catch all error
@@ -40,8 +40,8 @@
 
 
 // Define response codes as strings
-#define GENERIC_SUCCESS_STR                  "GENERIC_SUCCESS"
-#define GENERIC_ERROR_STR                    "GENERIC_ERROR"
+#define GENERIC_RINGSERVER_SUCCESS_STR       "GENERIC_RINGSERVER_SUCCESS"
+#define GENERIC_RINGSERVER_ERROR_STR         "GENERIC_RINGSERVER_ERROR"
 
 #define WRITE_SUCCESS_STR                    "WRITE_SUCCESS"
 #define WRITE_ERROR_STR                      "WRITE_ERROR"

--- a/src/ringserver_response_codes.h
+++ b/src/ringserver_response_codes.h
@@ -2,7 +2,7 @@
 #define RINGSERVER_RESPONSE_CODES_H
 
 /* Status Code Format: XYZ 
- * X : 0-n based on response group (ie GENERIC is 0, WRITE is 1, AUTHORIZATION is 2, and so on)
+ * X : 0-n based on response group (ie GENERIC is 0, WRITE is 1, AUTH(ORIZATION) is 2, and so on)
  * Y : 0-n increments as type changes within a response group
  * Z : 0 if success type, 1 if error type
  * 
@@ -16,16 +16,25 @@
  */
 
 // Define constant integer values for response status codes
-#define GENERIC_SUCCESS                 0
-#define GENERIC_ERROR                   1
+#define GENERIC_SUCCESS                   0
+#define GENERIC_ERROR                     1
 
-#define WRITE_SUCCESS                   100  // Catch all success
-#define WRITE_ERROR                     101  // Catch all error
-#define WRITE_INTERNAL ERROR            111  // Error due to error in ringserver
-#define WRITE_UNAUTHORIZED              121  // Client has no write permission (token)
-#define WRITE_STREAM_UNAUTHORIZED       131  // Client has write permission (token) but doesn't authorize write on this stream
-#define WRITE_NO_DEVICE_LINKED          141  // Client has write permission (token) but has no specified device to write on
-#define WRITE_EXPIRED_TOKEN             151  // Client's write permission (token) is expired
+#define WRITE_SUCCESS                     100  // Catch all success
+#define WRITE_ERROR                       101  // Catch all error
+#define WRITE_INTERNAL_ERROR              111  // Error due to error in ringserver
+#define WRITE_UNAUTHORIZED_ERROR          121  // Client has no write permission (token)
+#define WRITE_STREAM_UNAUTHORIZED_ERROR   131  // Client has write permission (token) but doesn't authorize write on this stream
+#define WRITE_NO_DEVICE_ERROR             141  // Client has write permission (token) but has no specified device to write on
+#define WRITE_EXPIRED_TOKEN_ERROR         151  // Client's write permission (token) is expired
+                                             
+#define AUTH_SUCCESS                      200
+#define AUTH_ERROR                        201
+#define AUTH_INTERNAL_ERROR               211  // Error due to error within ringserver processes
+#define AUTH_TOKEN_SIZE_ERROR             221  // Size of token isn't as expected (ie too large)
+#define AUTH_INVALID_TOKEN_ERROR          231  // Token is not a valid token from AuthServer
+#define AUTH_ROLE_INVALID_ERROR           241  // Role in token isn't what's expected (ie should be sensor)
+#define AUTH_EXPIRED_TOKEN_ERROR          251  // Token is expired
+                                                                                             
                                       
 // Define response codes as strings
 #define GENERIC_SUCCESS_STR                 "GENERIC_SUCCESS"
@@ -34,8 +43,8 @@
 #define WRITE_SUCCESS_STR                   "WRITE_SUCCESS"
 #define WRITE_ERROR_STR                     "WRITE_ERROR"
 
-#define AUTHORIZATION_SUCCESS_STR           "AUTHORIZATION_SUCCESS"
-#define AUTHORIZATION_ERROR_STR             "AUTHORIZATION_ERROR"
+#define AUTH_SUCCESS_STR           "AUTH_SUCCESS"
+#define AUTH_ERROR_STR             "AUTH_ERROR"
 
 // Define the default messages for each response status code
 #define GENERIC_SUCCESS_MSG                 "Success"


### PR DESCRIPTION
<!--- Add title with the following format,

type: [SEISMO-XXXX] SHORTENED TASK TITLE

where type is:
1. draft - to be completed PR
2. feat - new feature
3. fix - bug fixes
4. test - unit tests
5. chore - (aka housekeeping) cleaning/styling/refactor code, documentations, adding comments
--> 

# Detailed Description

### Summary
<!--- Please link the related issue/task --> 
> This PR fixes: [SEISMO 0016 - Change reconnect routines](https://www.notion.so/jeffsanchez/ISSUE-0016-303eff0b880243e89e3199cfe3321c28?pvs=4)
> This PR fixes: [SEISMO 0017 - Follow standard error codes](https://www.notion.so/jeffsanchez/ISSUE-0017-902fffa8b4064666b828370fd6a5236d?pvs=4)

<!--- Please include a detailed summary of the changes --> 
 - `HandleWrite()` was altered so that all the `SendPacket()` calls follows the format `STATUS_CODE_STR(STATUS_CODE_NUM): Error message`, where the constants are defined in the ringserver_response_codes.h
 - In `HandleNegotiation()`'s case `AUTHORIZATION`, analogous changes as above were applied. 

### Motivation & Context
These changes were applied so that the slink2dali program may have a more fine-grained actions based on the responses of the ringserver (instead of simply disconnecting and reconnecting every time an error is encountered)

### Type of change
<!--- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<!--- If breaking change, detail which existing functionality/s should or is expected to change -->


# How Has This Been Tested?
See tests in this [accompanying PR to slink2dali](https://github.com/UPRI-earthquake/sender-slink2dali/pull/2)

# Checklist:
<!--- Double check the following and leave uncheck those that you haven't done or are not applicable. -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ x Any dependent changes have been merged and published in downstream modules
