### PR TITLE
fix: [ISSUE-0023] - Remove streamIds from JWT & Create /sse-streams

### DIFF
--- a/doc/ring.conf
+++ b/doc/ring.conf
@@ -17,7 +17,7 @@ RingDirectory ring
 AuthDir auth
 
 # HTTP endpoint for token verification on the Authentication Server
-AuthServer http://172.22.0.3:5000/accounts/verifySensorToken
+AuthServer http://172.22.0.3:5000/accounts/verify-sensor-token
 
 # Specify the ring packet buffer size in bytes.  A trailing
 # 'K', 'M' or 'G' may be added for kilo, mega or giga bytes.

--- a/src/clients.c
+++ b/src/clients.c
@@ -404,7 +404,6 @@ ClientThread (void *arg)
     }
   } /* End of main client loop */
 
-  lprintf(0, "CHECKING (407): writepattern[1] = %p", cinfo->writepatterns[1]);
 
   /* Set thread CLOSING status, locking entire client list */
   pthread_mutex_lock (&cthreads_lock);
@@ -426,7 +425,6 @@ ClientThread (void *arg)
     WriteTLog (cinfo, 1);
   }
 
-  lprintf(0, "CHECKING (429): writepattern[1] = %p", cinfo->writepatterns[1]);
   /* Release match, reject and selectors strings */
   if (cinfo->matchstr)
     free (cinfo->matchstr);
@@ -451,36 +449,27 @@ ClientThread (void *arg)
     cinfo->authorized = 0;
     cinfo->tokenExpiry = 0;
   }
-  lprintf(0, "CHECKING (454): writepattern[1] = %p", cinfo->writepatterns[1]);
   if (cinfo->username){
-    lprintf(0, "username %s will be freed", cinfo->username);
     free(cinfo->username);
   }
   if (cinfo->role){
-    lprintf(0, "role %s will be freed", cinfo->role);
-    lprintf(0, "CHECKING: writepattern[1] = %p", cinfo->writepatterns[1]);
     free(cinfo->role);
   }
   if (cinfo->writepatterns){
     for(int i=0; i < cinfo->writepattern_count; i++){
       if(cinfo->writepatterns[i]){
-        lprintf(0, "writepattern[ %d ] = %p will be freed", i, cinfo->writepatterns[i]);
-        lprintf(0, "writepattern[ %d ] = %p will be freed next", i+1, cinfo->writepatterns[i+1]);
         pcre_free (cinfo->writepatterns[i]); // free each pattern in array
       }
     }
     free(cinfo->writepatterns); // free pointer to arry
-    lprintf(0, "writepatterns freed");
   }
   if (cinfo->writepatterns_str){
     for(int i=0; i < cinfo->writepattern_count; i++){
       if(cinfo->writepatterns_str[i]){
         free (cinfo->writepatterns_str[i]); // free each string in array
-        lprintf(0, "writepattern_str[ %d ] freed", i);
       }
     }
     free (cinfo->writepatterns_str); // free via pointer to array block
-    lprintf(0, "writepatterns_str freed");
   }
 
 
@@ -500,12 +489,9 @@ ClientThread (void *arg)
     free (cinfo->packetdata);
 
 
-  lprintf(0, "sendbuf, recvbuf, packetdata freed");
-
   /* Release client socket structure */
   if (cinfo->addr){
     free (cinfo->addr);
-    lprintf(0, "addr freed");
   }
 
   /* Shutdown and release miniSEED write data stream */
@@ -514,7 +500,6 @@ ClientThread (void *arg)
     ds_streamproc (cinfo->mswrite, NULL, NULL, cinfo->hostname);
     free (cinfo->mswrite);
     cinfo->mswrite = 0;
-    lprintf(0, "mswrite freed");
   }
 
   if (cinfo->type == CLIENT_SEEDLINK && cinfo->extinfo)

--- a/src/clients.c
+++ b/src/clients.c
@@ -31,6 +31,7 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include <pcre.h>
 
 #include "ringserver.h"
 #include "clients.h"
@@ -403,6 +404,8 @@ ClientThread (void *arg)
     }
   } /* End of main client loop */
 
+  lprintf(0, "CHECKING (407): writepattern[1] = %p", cinfo->writepatterns[1]);
+
   /* Set thread CLOSING status, locking entire client list */
   pthread_mutex_lock (&cthreads_lock);
   mytdp->td_flags = TDF_CLOSING;
@@ -423,6 +426,7 @@ ClientThread (void *arg)
     WriteTLog (cinfo, 1);
   }
 
+  lprintf(0, "CHECKING (429): writepattern[1] = %p", cinfo->writepatterns[1]);
   /* Release match, reject and selectors strings */
   if (cinfo->matchstr)
     free (cinfo->matchstr);
@@ -447,23 +451,36 @@ ClientThread (void *arg)
     cinfo->authorized = 0;
     cinfo->tokenExpiry = 0;
   }
+  lprintf(0, "CHECKING (454): writepattern[1] = %p", cinfo->writepatterns[1]);
   if (cinfo->username){
+    lprintf(0, "username %s will be freed", cinfo->username);
     free(cinfo->username);
   }
   if (cinfo->role){
+    lprintf(0, "role %s will be freed", cinfo->role);
+    lprintf(0, "CHECKING: writepattern[1] = %p", cinfo->writepatterns[1]);
     free(cinfo->role);
   }
   if (cinfo->writepatterns){
     for(int i=0; i < cinfo->writepattern_count; i++){
-      pcre_free (cinfo->writepatterns[i]); // free each pattern in array
+      if(cinfo->writepatterns[i]){
+        lprintf(0, "writepattern[ %d ] = %p will be freed", i, cinfo->writepatterns[i]);
+        lprintf(0, "writepattern[ %d ] = %p will be freed next", i+1, cinfo->writepatterns[i+1]);
+        pcre_free (cinfo->writepatterns[i]); // free each pattern in array
+      }
     }
     free(cinfo->writepatterns); // free pointer to arry
+    lprintf(0, "writepatterns freed");
   }
   if (cinfo->writepatterns_str){
     for(int i=0; i < cinfo->writepattern_count; i++){
-      free (cinfo->writepatterns_str[i]); // free each string in array
+      if(cinfo->writepatterns_str[i]){
+        free (cinfo->writepatterns_str[i]); // free each string in array
+        lprintf(0, "writepattern_str[ %d ] freed", i);
+      }
     }
     free (cinfo->writepatterns_str); // free via pointer to array block
+    lprintf(0, "writepatterns_str freed");
   }
 
 
@@ -482,9 +499,13 @@ ClientThread (void *arg)
   if (cinfo->packetdata)
     free (cinfo->packetdata);
 
+
+  lprintf(0, "sendbuf, recvbuf, packetdata freed");
+
   /* Release client socket structure */
   if (cinfo->addr){
     free (cinfo->addr);
+    lprintf(0, "addr freed");
   }
 
   /* Shutdown and release miniSEED write data stream */
@@ -493,6 +514,7 @@ ClientThread (void *arg)
     ds_streamproc (cinfo->mswrite, NULL, NULL, cinfo->hostname);
     free (cinfo->mswrite);
     cinfo->mswrite = 0;
+    lprintf(0, "mswrite freed");
   }
 
   if (cinfo->type == CLIENT_SEEDLINK && cinfo->extinfo)

--- a/src/dlclient.c
+++ b/src/dlclient.c
@@ -879,11 +879,7 @@ HandleNegotiation (ClientInfo *cinfo)
 
     // Get first layer of values (except "message")
     json_t *status = json_object_get(jsonResponse, "status");
-    json_t *sensorInfo = json_object_get(jsonResponse, "sensorInfo");
-    if(
-      status == NULL         || ( !json_is_integer(status)  ) ||
-      sensorInfo == NULL     || ( !json_is_object(sensorInfo)  )
-    ) {
+    if(status == NULL         || ( !json_is_integer(status)  )) {
       lprintf (0, "[%s] %s: Error parsing jsonResponse from AuthServer",
           cinfo->hostname, AUTH_INTERNAL_ERROR_STR);
       json_decref(jsonResponse);
@@ -895,6 +891,7 @@ HandleNegotiation (ClientInfo *cinfo)
     if (authserver_response_code == INBEHALF_VERIFICATION_SUCCESS)
     {
       // Get JSON components
+      json_t *sensorInfo = json_object_get(jsonResponse, "sensorInfo");
       json_t *username = json_object_get(sensorInfo, "username");
       json_t *role = json_object_get(sensorInfo, "role");
       json_t *exp_ptr = json_object_get(sensorInfo, "tokenExp");
@@ -902,6 +899,7 @@ HandleNegotiation (ClientInfo *cinfo)
 
       // Check expected data types
       if(
+        sensorInfo == NULL     || ( !json_is_object(sensorInfo)  ) ||
         username == NULL       || ( !json_is_string(username)    ) ||
         role == NULL           || ( !json_is_string(role)        ) ||
         exp_ptr == NULL        || ( !json_is_integer(exp_ptr)    ) ||
@@ -911,7 +909,7 @@ HandleNegotiation (ClientInfo *cinfo)
 
         lprintf (0, "[%s] %s: Error parsing sensorInfo from AuthServer response",
             cinfo->hostname, AUTH_INTERNAL_ERROR_STR);
-                                   //
+
         snprintf (sendbuffer, sizeof (sendbuffer), "%s(%d): RingServer encountered an error",
             AUTH_INTERNAL_ERROR_STR, AUTH_INTERNAL_ERROR);
         if (SendPacket (cinfo, "ERROR", sendbuffer, 0, 1, 1)){

--- a/src/dlclient.c
+++ b/src/dlclient.c
@@ -978,7 +978,7 @@ HandleNegotiation (ClientInfo *cinfo)
         if (json_is_string(streamId))
         {
           // Compile pcre pattern from string, assign to cinfo
-          const char *streamIdStr = json_string_value(streamId);
+          const char *streamIdStr = json_string_value(streamId); // returns null terminated string
           pcre *pattern = pcre_compile (streamIdStr, 0, &errptr, &erroffset, NULL); // allocates automatically
           if (errptr){
             lprintf (0, "[%s] %s: Error with JWTToken & pcre_compile: %s (offset: %d)", cinfo->hostname,

--- a/src/dlclient.c
+++ b/src/dlclient.c
@@ -34,10 +34,11 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <time.h>
-#include <curl/curl.h>
 
+#include <curl/curl.h>
 #include <libmseed.h>
 #include <mxml.h>
+#include <pcre.h>
 #include <jansson.h>
 
 #include "clients.h"
@@ -882,36 +883,70 @@ HandleNegotiation (ClientInfo *cinfo)
     if (authserver_response_code == INBEHALF_VERIFICATION_SUCCESS)
     {
       // Get JSON components
-      json_t *decodedSenderToken = json_object_get(jsonResponse, "decodedSenderToken");
-      json_t *exp_ptr = json_object_get(decodedSenderToken, "exp");
-      json_t *streamIdsArray = json_object_get(decodedSenderToken, "streamIds");
+      json_t *sensorInfo = json_object_get(jsonResponse, "sensorInfo");
+      json_t *username = json_object_get(sensorInfo, "username");
+      json_t *role = json_object_get(sensorInfo, "role");
+      json_t *exp_ptr = json_object_get(sensorInfo, "tokenExp");
+      json_t *streamIdsArray = json_object_get(sensorInfo, "streamIds"); // Array of strings
 
       // Check expected data types
-      if (exp_ptr == NULL || ( !json_is_integer(exp_ptr) )) {
-        // TODO: Handle this correctly, response with "ERROR" ?
-        // TODO: Refactor this code (maybe write this into a function) to avoid too much
+      if(
+        sensorInfo == NULL     || ( !json_is_object(sensorInfo)  ) ||
+        username == NULL       || ( !json_is_string(username)    ) ||
+        role == NULL           || ( !json_is_string(role)        ) ||
+        exp_ptr == NULL        || ( !json_is_integer(exp_ptr)    ) ||
+        streamIdsArray == NULL || ( !json_is_array(streamIdsArray) )
+      ) {
+        lprintf (0, "[%s] %s: Error parsing sensorInfo from AuthServer response",
+            cinfo->hostname, AUTH_INTERNAL_ERROR_STR);
+
         // freeing because of early return
-        lprintf(0, "Error parsing expiration from token");
-        json_decref(streamIdsArray);
-        json_decref(decodedSenderToken);
-        json_decref(jsonResponse);
-        return -1;
+        if(sensorInfo)     json_decref(sensorInfo);
+        if(username)       json_decref(username);
+        if(role)           json_decref(role);
+        if(exp_ptr)        json_decref(exp_ptr);
+        if(streamIdsArray) json_decref(streamIdsArray);
+
+        snprintf (sendbuffer, sizeof (sendbuffer), "%s(%d): RingServer encountered an error",
+            AUTH_INTERNAL_ERROR_STR, AUTH_INTERNAL_ERROR);
+        if (SendPacket (cinfo, "ERROR", sendbuffer, 0, 1, 1)){
+          return -1;
+        }else{
+          return 0;
+        }
       }
 
-      if (streamIdsArray == NULL || ( !json_is_array(streamIdsArray) )) {
-        // TODO: Handle this correctly, response with "ERROR" ?
-        lprintf(0, "Error parsing streamIds from token");
-        json_decref(exp_ptr);
-        json_decref(decodedSenderToken);
-        json_decref(jsonResponse);
-        return -1;
-      }
-
-      // Assign to cinfo
+      // Assign tokenExpiry to cinfo
       cinfo->tokenExpiry = json_integer_value(exp_ptr);
       lprintf(1, "[%s] Token expiration: %d", cinfo->hostname, cinfo->tokenExpiry);
       json_decref(exp_ptr); // no more need for this
 
+      //Assign username and role to cinfo
+      cinfo->username = (char*)malloc( (strlen( json_string_value(username) )+1) );
+      cinfo->role = (char*)malloc( (strlen( json_string_value(role) )+1) );
+      if (cinfo->username == NULL || cinfo->role == NULL) {
+        lprintf (0, "[%s] Error allocating memory for username & role", cinfo->hostname);
+        if(sensorInfo)     json_decref(sensorInfo);
+        if(username)       json_decref(username);
+        if(role)           json_decref(role);
+        if(streamIdsArray) json_decref(streamIdsArray);
+        return -1;
+      }
+      strncpy(
+        cinfo->username, 
+        json_string_value(username),
+        strlen( json_string_value(username) )
+      );
+      strncpy(
+        cinfo->role,
+        json_string_value(role),
+        strlen( json_string_value(role) )
+      );
+      json_decref(username); // no more need for this
+      json_decref(role);
+      lprintf(1, "username = %s, role = %s", cinfo->username, cinfo->role);
+
+      // Assign StreamIds str and pcre to cinfo
       // Iterate over the elements in the streamIds array
       size_t index;
       json_t *streamId;
@@ -924,21 +959,11 @@ HandleNegotiation (ClientInfo *cinfo)
       if (num_streams > DL_MAX_NUM_STREAMID){
         lprintf(0, "Error number of streamIds (%zu) exceeded maximum: %d",
             num_streams, DL_MAX_NUM_STREAMID);
-        json_decref(exp_ptr);
-        json_decref(decodedSenderToken);
+        json_decref(streamIdsArray);
+        json_decref(sensorInfo);
         json_decref(jsonResponse);
         return -1;
       }
-
-      //TODO: Get these from AuthServer response
-      cinfo->username = (char*)malloc( (strlen("username")+1) * sizeof(char) );
-      cinfo->role = (char*)malloc( (strlen("role")+1) * sizeof(char) );
-      if (cinfo->username == NULL || cinfo->role == NULL) {
-        lprintf (0, "[%s] Error allocating memory for username & role", cinfo->hostname);
-      }
-      strcpy(cinfo->username, "username");
-      strcpy(cinfo->role, "role");
-      lprintf(1, "username = %s, role = %s", cinfo->username, cinfo->role);
 
       lprintf(1, "[%s] Number of streamIds %zu", cinfo->hostname, num_streams);
       cinfo->writepatterns_str = (char**)malloc(num_streams * sizeof(char*));
@@ -948,7 +973,7 @@ HandleNegotiation (ClientInfo *cinfo)
         lprintf (0, "[%s] Error allocating memory", cinfo->hostname);
 
         json_decref(streamIdsArray);
-        json_decref(decodedSenderToken);
+        json_decref(sensorInfo);
         json_decref(jsonResponse);
         return -1;
       }
@@ -956,9 +981,9 @@ HandleNegotiation (ClientInfo *cinfo)
       json_array_foreach(streamIdsArray, index, streamId) {
         if (json_is_string(streamId))
         {
-          // Compile pcre pattern from string
+          // Compile pcre pattern from string, assign to cinfo
           const char *streamIdStr = json_string_value(streamId);
-          pcre *pattern = pcre_compile (streamIdStr, 0, &errptr, &erroffset, NULL);
+          pcre *pattern = pcre_compile (streamIdStr, 0, &errptr, &erroffset, NULL); // allocates automatically
           if (errptr){
             lprintf (0, "[%s] %s: Error with JWTToken & pcre_compile: %s (offset: %d)", cinfo->hostname,
                 AUTH_INTERNAL_ERROR_STR, errptr, erroffset);
@@ -969,18 +994,30 @@ HandleNegotiation (ClientInfo *cinfo)
               ret = -1;
 
             json_decref(streamIdsArray);
-            json_decref(decodedSenderToken);
+            json_decref(sensorInfo);
             json_decref(jsonResponse);
             return ret;
           }
-          cinfo->writepatterns[cinfo->writepattern_count] = pattern;
 
+          int patternSize = 0;
+          pcre_fullinfo(pattern, NULL, PCRE_INFO_SIZE, &patternSize); // get size of pcre struct in bytes
+          cinfo->writepatterns[cinfo->writepattern_count] = (pcre*)malloc(patternSize); // get a pointer to a block of size patternSize
+          lprintf(1, "Allocated writepatter[%d] addr=%p", cinfo->writepattern_count, cinfo->writepatterns[cinfo->writepattern_count]);
+          if (cinfo->writepatterns[cinfo->writepattern_count] == NULL) {
+            lprintf (0, "[%s] Error allocating writepattern[i] memory", cinfo->hostname);
+            return -1;
+              // TODO: Error handling for memory allocation failure
+          }
+          memcpy(cinfo->writepatterns[cinfo->writepattern_count], pattern, patternSize);
+          //cinfo->writepatterns[cinfo->writepattern_count] = pattern;
+
+          // assign streamid_str to cinfo
           size_t pattern_str_size = (strlen(streamIdStr)+1) * sizeof(char);
           if (pattern_str_size > DL_MAX_STREAMID_STR_LEN){
             lprintf(0, "Length of streamId string (%s, %lu) exceeded maximum: %d",
                 streamIdStr, pattern_str_size, DL_MAX_STREAMID_STR_LEN);
             json_decref(exp_ptr);
-            json_decref(decodedSenderToken);
+            json_decref(sensorInfo);
             json_decref(jsonResponse);
             return -1;
           }
@@ -994,23 +1031,28 @@ HandleNegotiation (ClientInfo *cinfo)
           lprintf(0, "Invalid streamId at index %zu\n", index);
 
           json_decref(streamIdsArray);
-          json_decref(decodedSenderToken);
+          json_decref(sensorInfo);
           json_decref(jsonResponse);
           return -1;
         }
       }
+      // Cleanup
+      json_decref(streamId);
       json_decref(streamIdsArray);
+      json_decref(sensorInfo);
+      lprintf(0, "CHECKING (1043): writepattern[1] = %p", cinfo->writepatterns[1]);
 
       // Print stream IDs
       int i;
       lprintf(1, "[%s] Stream IDs:", cinfo->hostname);
       for (i = 0; i < cinfo->writepattern_count; i++) {
-        lprintf(1, "[%s]    %s", cinfo->hostname, cinfo->writepatterns_str[i]);
+        lprintf(1, "[%s] %s addr=%p", cinfo->hostname, cinfo->writepatterns_str[i], cinfo->writepatterns[i]);
       }
 
       // Update write authority flag
       cinfo->authorized = 1;
 
+      lprintf(0, "CHECKING (1052): writepattern[1] = %p", cinfo->writepatterns[1]);
       lprintf (1, "[%s] %s: Granted authorization to WRITE on streamIds", cinfo->hostname, AUTH_SUCCESS_STR);
       snprintf (sendbuffer, sizeof (sendbuffer),
           "%s(%d): Granted authorization to WRITE on streamIds",
@@ -1019,24 +1061,7 @@ HandleNegotiation (ClientInfo *cinfo)
       if (SendPacket (cinfo, "OK", sendbuffer, 0, 1, 1))
         ret = -1;
 
-      // Cleanup
-      json_decref(decodedSenderToken);
     }
-#if 0 // This part will be removed once jwt's don't store streamids in them anymore
-    else if (response_code == INBEHALF_VERIFICATION_SUCCESS_NEW_TOKEN)
-    {
-      //const char *accessToken = json_string_value(json_object_get(decodedSenderToken, "accessToken"));
-      lprintf (1, "[%s] AUTH_OK: Granted authorization to WRITE on streamIds, added to list of devices", cinfo->hostname);
-      snprintf (sendbuffer, sizeof (sendbuffer),
-          "AUTH_OK: Granted authorization to WRITE on streamIds, added to list of devices");
-      // TODO: add to jwttoken and writepattern
-
-      if (SendPacket (cinfo, "OK", sendbuffer, 0, 1, 1))
-        ret = -1;
-
-      // TODO: Update bearertoken
-    }
-#endif
     else if (authserver_response_code == INBEHALF_VERIFICATION_INVALID_TOKEN)
     {
       lprintf (0, "[%s] %s: Sensor token invalid", cinfo->hostname, AUTH_INVALID_TOKEN_ERROR_STR);
@@ -1073,7 +1098,8 @@ HandleNegotiation (ClientInfo *cinfo)
     }
 
     // Cleanup
-    json_decref(jsonResponse);
+    lprintf(0, "CHECKING (1099): writepattern[1] = %p", cinfo->writepatterns[1]);
+    if(jsonResponse) json_decref(jsonResponse);
     return ret;
   }
 

--- a/src/dlclient.c
+++ b/src/dlclient.c
@@ -993,7 +993,6 @@ HandleNegotiation (ClientInfo *cinfo)
             return ret;
           }
           cinfo->writepatterns[cinfo->writepattern_count] = pattern;
-          lprintf(1, "Allocated writepattern[%d] addr=%p", cinfo->writepattern_count, cinfo->writepatterns[cinfo->writepattern_count]);
 
           // assign streamid_str to cinfo
           size_t pattern_str_size = (strlen(streamIdStr)+1) * sizeof(char);
@@ -1023,14 +1022,13 @@ HandleNegotiation (ClientInfo *cinfo)
       int i;
       lprintf(1, "[%s] Stream IDs:", cinfo->hostname);
       for (i = 0; i < cinfo->writepattern_count; i++) {
-        lprintf(1, "[%s] %s addr=%p", cinfo->hostname, cinfo->writepatterns_str[i], cinfo->writepatterns[i]);
+        lprintf(1, "[%s]    %s", cinfo->hostname, cinfo->writepatterns_str[i]);
       }
 
       // Update write authority flag
       cinfo->authorized = 1;
 
       // Respond
-      lprintf(0, "CHECKING (1052): writepattern[1] = %p", cinfo->writepatterns[1]);
       lprintf (1, "[%s] %s: Granted authorization to WRITE on streamIds", cinfo->hostname, AUTH_SUCCESS_STR);
       snprintf (sendbuffer, sizeof (sendbuffer),
           "%s(%d): Granted authorization to WRITE on streamIds",

--- a/src/dlclient.c
+++ b/src/dlclient.c
@@ -935,12 +935,12 @@ HandleNegotiation (ClientInfo *cinfo)
       strncpy(
         cinfo->username, 
         json_string_value(username),
-        strlen( json_string_value(username) )
+        strlen( json_string_value(username) ) + 1
       );
       strncpy(
         cinfo->role,
         json_string_value(role),
-        strlen( json_string_value(role) )
+        strlen( json_string_value(role) ) + 1 
       );
       json_decref(username); // no more need for this
       json_decref(role);
@@ -999,17 +999,19 @@ HandleNegotiation (ClientInfo *cinfo)
             return ret;
           }
 
+          /*
           int patternSize = 0;
           pcre_fullinfo(pattern, NULL, PCRE_INFO_SIZE, &patternSize); // get size of pcre struct in bytes
           cinfo->writepatterns[cinfo->writepattern_count] = (pcre*)malloc(patternSize); // get a pointer to a block of size patternSize
-          lprintf(1, "Allocated writepatter[%d] addr=%p", cinfo->writepattern_count, cinfo->writepatterns[cinfo->writepattern_count]);
           if (cinfo->writepatterns[cinfo->writepattern_count] == NULL) {
             lprintf (0, "[%s] Error allocating writepattern[i] memory", cinfo->hostname);
             return -1;
               // TODO: Error handling for memory allocation failure
           }
           memcpy(cinfo->writepatterns[cinfo->writepattern_count], pattern, patternSize);
-          //cinfo->writepatterns[cinfo->writepattern_count] = pattern;
+          */
+          cinfo->writepatterns[cinfo->writepattern_count] = pattern;
+          lprintf(1, "Allocated writepattern[%d] addr=%p", cinfo->writepattern_count, cinfo->writepatterns[cinfo->writepattern_count]);
 
           // assign streamid_str to cinfo
           size_t pattern_str_size = (strlen(streamIdStr)+1) * sizeof(char);
@@ -1038,9 +1040,11 @@ HandleNegotiation (ClientInfo *cinfo)
       }
       // Cleanup
       json_decref(streamId);
+      lprintf(0, "CHECKING (1041): writepattern[1] = %p", cinfo->writepatterns[1]);
       json_decref(streamIdsArray);
-      json_decref(sensorInfo);
       lprintf(0, "CHECKING (1043): writepattern[1] = %p", cinfo->writepatterns[1]);
+      //json_decref(sensorInfo);
+      lprintf(0, "CHECKING (1045): writepattern[1] = %p", cinfo->writepatterns[1]);
 
       // Print stream IDs
       int i;
@@ -1098,8 +1102,8 @@ HandleNegotiation (ClientInfo *cinfo)
     }
 
     // Cleanup
-    lprintf(0, "CHECKING (1099): writepattern[1] = %p", cinfo->writepatterns[1]);
-    if(jsonResponse) json_decref(jsonResponse);
+    //if(jsonResponse) json_decref(jsonResponse);
+    lprintf(0, "CHECKING (1106): writepattern[1] = %p", cinfo->writepatterns[1]);
     return ret;
   }
 

--- a/src/http.c
+++ b/src/http.c
@@ -1511,7 +1511,7 @@ GenerateStreamsSSE (ClientInfo *cinfo, char **streamlist, char *path, int idsonl
   ms_hptime2mdtimestr (hpnow, timenow, 1);
   snprintf (streaminfo, sizeof (streaminfo),
             "],"
-            "\"time\": \"%s\""
+            "\"current_time\": \"%s\""
             "}\n\n",
             timenow);
   AddToString (streamlist, streaminfo, "", 0, 8388608);
@@ -2035,7 +2035,7 @@ GenerateConnectionsSSE (ClientInfo *cinfo, char **connectionlist, char *path)
   ms_hptime2mdtimestr (hpnow, timenow, 1);
   snprintf (conninfo, sizeof (conninfo),
             "],"
-            "\"time\": \"%s\","
+            "\"current_time\": \"%s\","
             "\"num_selected_connections\": \"%d\","
             "\"total_num_connections\": \"%d\""
             "}\n\n",


### PR DESCRIPTION
<!--- Add title with the following format,

type: [SEISMO-XXXX] SHORTENED TASK TITLE

where type is:
1. draft - to be completed PR
2. feat - new feature
3. fix - bug fixes
4. test - unit tests
5. chore - (aka housekeeping) cleaning/styling/refactor code, documentations, adding comments
--> 

# Detailed Description

### Summary
<!--- Please link the related issue/task --> 
> This PR fixes: [ISSUE-0023](https://www.notion.so/jeffsanchez/ISSUE-0023-fe90bed4017744db8789b51e9272846f)

<!--- Please include a detailed summary of the changes --> 
 +  Receipt of the response from AuthServer was refactored to also store "username" and "role." A new format of the JSON response was also used ([as per earthquake-hub-backend format](https://github.com/UPRI-earthquake/earthquake-hub-backend/compare/dev...removeJWT?expand=1))
 + The use of `json_decref()` was fixed, it's now only used to decref jsonResponse (a New reference, instead of decref-ing borrowed references). 
+ /sse-connections http endpoint was fixed to properly include all streamids of a single connection as an array of strings.
+ /sse-connections was also fixed to follow correct SSE format (with named events and data key). Note the new format of each SSE message:
    ```json
    event: ringserver-connections-status\n
    data: 
    {
        "connections": [
        {
            "protocol": "Unknown",
            "connection_time": "2023-07-06 08:19:20.733105",
            "hostname": "localhost",
            "username": "none",
            "role": "none",
            "num_rx_packets": "0",
            "rx_packets_per_sec": "0.0",
            "num_rx_bytes": "0",
            "rx_bytes_per_sec": "0.0",
            "lag_ms": "0.1",
            "stream_count": "0",
            "stream_ids": []
        },
        {
            "protocol": "DataLink",
            "connection_time": "2023-07-06 08:14:23.009189",
            "hostname": "localhost",
            "username": "citizen",
            "role": "sensor",
            "num_rx_packets": "206",
            "rx_packets_per_sec": "1.0",
            "num_rx_bytes": "105472",
            "rx_bytes_per_sec": "511.8",
            "lag_ms": "0.2",
            "stream_count": "16",
            "stream_ids": ["GE_TOLI2_.*/MSEED","AM_RE722_.*/MSEED"]
        }],
        "current_time": "2023-07-06 08:19:20.833048",
         "num_selected_connections": "5",
         "total_num_connections": "5"
    }
   \n\n
    ```
+ /sse-streams was added to give a "per stream/device" info on last connected time (as opposed to "per connection/account" info in /sse-connections. The following is the format of each SSE message.
    ``` json
    event: ringserver-streamids-status\n
    data: 
    {
        "stream_ids": [
        {
             "stream_id":"AM_RE722_00_EHZ/MSEED",
             "earliest_data_start_time":"2023-06-27T11:30:51.183000Z",
            "latest_data_end_time":"2023-06-27T12:16:40.493000Z"
        },
        {
            "stream_id":"GE_TOLI2__BHE/MSEED",
            "earliest_data_start_time":"2023-05-30T11:21:37.069538Z", 
            "latest_data_end_time":"2023-06-09T10:15:00.969538Z"
        }],
       "current_time": "2023-07-06 08:19:20.833048"
     }
     \n\n
  ```

### Motivation & Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We have decided to exclude the streamids from the JWT for the following reasons:
1. So that the JWT strings won't have to grow in size as the number of streamids increase (specially for brgy accounts).
2.  To get rid of the bug  in W3 where since /deviceLink requires the device to get a TOKEN first before its streamid is updated from TO_BE_LINKED to actual value. Hence the token that is stored in the device has stream_id=TO_BE_LINKED since it has to get and store the token first before the stream_id value is changed.

### Type of change
<!--- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<!--- If breaking change, detail which existing functionality/s should or is expected to change -->


# How Has This Been Tested?
1. Using Google Chrome, visit 127.0.0.1:<Listen-Port>/sse-connections. This should show a new SSE message following the format every 3 seconds. Pressing X on the refresh button should show "Client disconnected" in RingServer logs.
2. Same as above but for 127.0.0.1:<Listen-Port>/sse-streams. You may try to connect a slink2dali forwarder to see that the messages should be updated.
3. Connecting slink2dali should now result to receiving a new token format from AuthServer. `username` and `role` and `streamIds` should be logged per connection. Closing the slink2dali connection should not cause memory error and should show "Client disconnected".


# Checklist:
<!--- Double check the following and leave uncheck those that you haven't done or are not applicable. -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
